### PR TITLE
fix: resolve timestamp ClassCastException

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/params/parsers/ScreenParamsParser.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/parsers/ScreenParamsParser.java
@@ -29,7 +29,12 @@ public class ScreenParamsParser extends Parser {
     public static ScreenParams parse(Bundle params) {
         ScreenParams result = new ScreenParams();
         result.screenId = params.getString(KEY_SCREEN_ID);
-        result.timestamp = params.getDouble(KEY_TIMESTAMP);
+        Object timestampObj = params.get(KEY_TIMESTAMP);
+        if(timestampObj instanceof Integer) {
+            result.timestamp = ((int) timestampObj) * 1.0;
+        } else if (timestampObj instanceof Double){
+            result.timestamp = (double) timestampObj;
+        }
         assertKeyExists(params, KEY_NAVIGATION_PARAMS);
         result.navigationParams = new NavigationParams(params.getBundle(KEY_NAVIGATION_PARAMS));
 


### PR DESCRIPTION
This resolves .push runtime exception when it try to cast a wrapper class Integer to Double. 
Please see the comments in the following post for reference:
https://github.com/wix/react-native-navigation/issues/2842